### PR TITLE
Update Candlestick.java

### DIFF
--- a/src/main/java/com/binance/api/client/domain/market/Candlestick.java
+++ b/src/main/java/com/binance/api/client/domain/market/Candlestick.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * Kline/Candlestick bars for a symbol. Klines are uniquely identified by their open time.
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
-@JsonPropertyOrder()
+@JsonPropertyOrder({"openTime", "open", "high", "low", "close", "volume","closeTime","quoteAssetVolume","numberOfTrades","takerBuyBaseAssetVolume","takerBuyQuoteAssetVolume"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Candlestick {
 


### PR DESCRIPTION
Define property order manually because the parsing order is not working correctly on Android